### PR TITLE
Keep 6to5 from dying if it is run after es6-transpiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,12 @@ module.exports = to5;
 
 function to5 ( code, options ) {
 	options.sourceMap = options.sourceMap !== false;
+
+	// 6to5 falls over if someone slips a contains method on the Array prototype (es6-transpiler)
+	if ( Array.prototype.hasOwnProperty( 'contains' ) ) {
+		delete Array.prototype.contains;
+	}
+
 	return require( '6to5-core' ).transform( code, options );
 }
 


### PR DESCRIPTION
I'm not positive this is the best place to do this, but it keeps incremental compilation after an es6-transpiler run from falling over.
