### PR TITLE
A fix for babel complaining about unknown options

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,5 +10,6 @@ function babel ( code, options ) {
 babel.id = 'babel';
 
 babel.defaults = {
-	accept: '.js'
+	accept: ['.js', '.es6'],
+	ext: 'js'
 };

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ module.exports = babel;
 
 function babel ( code, options ) {
 	options.sourceMap = options.sourceMap !== false;
+	delete options.accept;
+	delete options.ext;
 	return require( 'babel-core' ).transform( code, options );
 }
 


### PR DESCRIPTION
A suggestion to fix #2 - delete `accept` and `ext` options before passing through to babel.  I'm also suggesting the `.es6` extension is accepted by default, and that the default output extension is `.js`.

An alternative (but from the discussion I presume less desirable) fix is in the [ext-fix-2 branch](https://github.com/stewartml/gobble-babel/tree/ext-fix-2).
