### PR TITLE
Add importHelpers option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var babelc = require('babel-core');
-var resolveRc = require('babel-core/transformation/file/options/resolve-rc')
+var resolveRc = require('babel-core/lib/babel/transformation/file/options/resolve-rc')
 var sander = require('sander');
 var mapSeries = require('promise-map-series');
 var assign = require('lodash/object/assign');
@@ -12,7 +12,6 @@ function babel(inputdir, outputdir, opts) {
 	importHelpers = !!opts.importHelpers;
 	if (importHelpers) {
 		opts.externalHelpers = true;
-		opts.metadataUsedHelpers = true;
 	}
 	delete opts.importHelpers;
 	resolveRc(inputdir, opts);
@@ -55,13 +54,11 @@ function buildHelpers(usedHelpers, opts) {
 	var helpers1 = babelc.buildExternalHelpers(usedHelpers, "var");
 	opts = merge({}, opts, {
 		externalHelpers: true,
-		metadataUsedHelpers: true,
 		blacklist: ["strict", "es6.tailCall"]
 	}, mergeCustom);
 	addUniqueHelpers(usedHelpers,
 		babelc.transform(helpers1, opts).metadata.usedHelpers
 	);
-	delete opts.metadataUsedHelpers;
 	var helpers2 = babelc.buildExternalHelpers(usedHelpers, "var");
 	return "export " + babelc.transform(helpers2, opts).code;
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var babelc = require('babel-core');
-var resolveRc = require('babel-core/lib/babel/tools/resolve-rc')
+var resolveRc = require('babel-core/transformation/file/options/resolve-rc')
 var sander = require('sander');
 var mapSeries = require('promise-map-series');
 var assign = require('lodash/object/assign');

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var babelc = require('babel-core');
+var resolveRc = require('babel-core/lib/babel/tools/resolve-rc')
 var sander = require('sander');
 var mapSeries = require('promise-map-series');
 var objectAssign = require('object-assign');
@@ -7,39 +8,33 @@ var path = require('path');
 module.exports = babel;
 
 function babel(inputdir, outputdir, opts) {
-	if (opts.importHelpers) {
+	importHelpers = !!opts.importHelpers;
+	if (importHelpers) {
 		opts.externalHelpers = true;
 		opts.metadataUsedHelpers = true;
 	}
+	delete opts.importHelpers;
+	resolveRc(inputdir, opts);
 	return sander.lsr(inputdir).then(function(allFiles) {
 		allFiles = allFiles.filter(extFilter);
 		var usedHelpers = [];
 		return mapSeries(allFiles, function(filename) {
 			return sander.readFile(inputdir, filename).then(function(code) {
-				if (opts.importHelpers) {
+				if (importHelpers) {
 					var hf = slashes(filename) + '__babelHelpers.js';
 					code = 'import {babelHelpers} from "' + hf + '";\n' + code;
 				}
-				var fileOpts = objectAssign({}, opts, {
-					filename: inputdir + '/' + filename,
-					filenameRelative: filename
-				});
-				delete fileOpts.importHelpers;
-				var result = babelc.transform(code, fileOpts);
-				if (opts.importHelpers) {
-					var helpers = result.metadata.usedHelpers;
-					for (var i = helpers.length - 1; i >= 0; i--) {
-						if (usedHelpers.indexOf(helpers[i]) < 0) {
-							usedHelpers.push(helpers[i]);
-						}
-					}
+				var result = babelc.transform(code, objectAssign({}, opts, {
+					filename: inputdir + '/' + filename
+				}));
+				if (importHelpers) {
+					addUniqueHelpers(usedHelpers, result.metadata.usedHelpers);
 				}
 				return sander.writeFile(outputdir, filename, result.code);
 			});
 		}).then(function() {
-			if (opts.importHelpers) {
-				var code = babelc.buildExternalHelpers(usedHelpers, 'var');
-				code = "export " + code;
+			if (importHelpers) {
+				var code = buildHelpers(usedHelpers, opts);
 				return sander.writeFile(outputdir, '__babelHelpers.js', code);
 			}
 		});
@@ -53,6 +48,27 @@ function extFilter(filename) {
 function slashes(from) {
 	var count = from.split('/').length;
 	return count > 1 ? (new Array(count + 1)).join('../') : './';
+}
+
+function buildHelpers(usedHelpers, opts) {
+	var helpers1 = babelc.buildExternalHelpers(usedHelpers, "var");
+	addUniqueHelpers(usedHelpers,
+		babelc.transform(helpers1, objectAssign({}, opts, {
+			externalHelpers: true,
+			metadataUsedHelpers: true
+		})).metadata.usedHelpers
+	);
+	delete opts.metadataUsedHelpers;
+	var helpers2 = babelc.buildExternalHelpers(usedHelpers, "var");
+	return "export " + babelc.transform(helpers2, opts).code;
+}
+
+function addUniqueHelpers(dest, src) {
+	for (var i = src.length - 1; i >= 0; i--) {
+		if (dest.indexOf(src[i]) < 0) {
+			dest.push(src[i]);
+		}
+	}
 }
 
 babel.defaults = {

--- a/index.js
+++ b/index.js
@@ -1,13 +1,62 @@
-var transform = require( 'babel-core' ).transform;
+var babelc = require('babel-core');
+var sander = require('sander');
+var mapSeries = require('promise-map-series');
+var objectAssign = require('object-assign');
+var path = require('path');
 
 module.exports = babel;
 
-function babel ( code, options ) {
-	options.sourceMap = options.sourceMap !== false;
-	return transform( code, options );
+function babel(inputdir, outputdir, opts) {
+	if (opts.importHelpers) {
+		opts.externalHelpers = true;
+		opts.metadataUsedHelpers = true;
+	}
+	return sander.lsr(inputdir).then(function(allFiles) {
+		allFiles = allFiles.filter(extFilter);
+		var usedHelpers = [];
+		return mapSeries(allFiles, function(filename) {
+			return sander.readFile(inputdir, filename).then(function(code) {
+				if (opts.importHelpers) {
+					var hf = slashes(filename) + '__babelHelpers.js';
+					code = 'import babelHelpers from "' + hf + '";\n' + code;
+				}
+				var fileOpts = objectAssign({}, opts, {
+					filename: inputdir + '/' + filename,
+					filenameRelative: filename
+				});
+				delete fileOpts.importHelpers;
+				var result = babelc.transform(code, fileOpts);
+				if (opts.importHelpers) {
+					var helpers = result.metadata.usedHelpers;
+					for (var i = helpers.length - 1; i >= 0; i--) {
+						if (usedHelpers.indexOf(helpers[i]) < 0) {
+							usedHelpers.push(helpers[i]);
+						}
+					}
+				}
+				return sander.writeFile(outputdir, filename, result.code);
+			});
+		}).then(function() {
+			if (opts.importHelpers) {
+				var code = babelc.buildExternalHelpers(usedHelpers, 'var');
+				code = code + '\nexport default babelHelpers;';
+				return sander.writeFile(outputdir, '__babelHelpers.js', code);
+			}
+		});
+	});
+}
+
+function extFilter(filename) {
+	return /\.(js|es6)$/.test(filename)
+}
+
+function slashes(from) {
+	var count = from.split('/').length;
+	return count > 1 ? (new Array(count + 1)).join('../') : './';
 }
 
 babel.defaults = {
-	accept: [ '.js', '.es6' ],
-	ext: '.js'
+	accept: ['.js', '.es6'],
+	ext: '.js',
+	sourceMap: true
 };

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function babel(inputdir, outputdir, opts) {
 			return sander.readFile(inputdir, filename).then(function(code) {
 				if (opts.importHelpers) {
 					var hf = slashes(filename) + '__babelHelpers.js';
-					code = 'import babelHelpers from "' + hf + '";\n' + code;
+					code = 'import {babelHelpers} from "' + hf + '";\n' + code;
 				}
 				var fileOpts = objectAssign({}, opts, {
 					filename: inputdir + '/' + filename,
@@ -39,7 +39,7 @@ function babel(inputdir, outputdir, opts) {
 		}).then(function() {
 			if (opts.importHelpers) {
 				var code = babelc.buildExternalHelpers(usedHelpers, 'var');
-				code = code + '\nexport default babelHelpers;';
+				code = "export " + code;
 				return sander.writeFile(outputdir, '__babelHelpers.js', code);
 			}
 		});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/babel/gobble-babel",
   "dependencies": {
     "babel-core": "^5.0.0",
-    "object-assign": "^2.0.0",
+    "lodash": "^3.7.0",
     "promise-map-series": "^0.2.1",
     "sander": "^0.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "license": "MIT",
   "repository": "https://github.com/babel/gobble-babel",
   "dependencies": {
-    "babel-core": "^5.0.0"
+    "babel-core": "^5.0.0",
+    "object-assign": "^2.0.0",
+    "promise-map-series": "^0.2.1",
+    "sander": "^0.2.3"
   },
   "keywords": [
     "gobble"


### PR DESCRIPTION
Adds `importHelpers` option that causes used helpers to be imported as an external file. Works well with [gobble-esperanto-bundle](https://github.com/esperantojs/gobble-esperanto-bundle).

Example:

``` javascript
var gobble = require("gobble");

module.exports = gobble("app")
.transform("babel", {
    blacklist: ["strict", "es6.modules"],
    importHelpers: true
})
.transform("esperanto-bundle", {
    entry: "index.js",
    type: "umd",
    name: "myapp",
    dest: "myapp"
});
```

The `.babelrc` file is also respected (wasn't before).

The only thing I haven't figured out is the map file generated by esperanto-bundle is referring to the `.gobble-build` directory.
