### PR TITLE
Add: buildExternalHelpers when externalHelpers enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function babel ( code, options ) {
 
 	if ( options.externalHelpers ) {
 		var helpers = babelCore.buildExternalHelpers( result.metadata.usedHelpers );
-		result.code = helpers + '\n\n' + result.code;
+		result.write( helpers );
 	}
 	return result;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var transform = require( 'babel-core' ).transform;
+var babelCore = require( 'babel-core' );
 var dirname = require( 'path' ).dirname;
 
 module.exports = babel;
@@ -9,7 +9,13 @@ function babel ( code, options ) {
 	// trigger use of .babelrc
 	options.filename = this.src;
 
-	return transform( code, options );
+	var result = babelCore.transform( code, options );
+
+	if ( options.externalHelpers ) {
+		var helpers = babelCore.buildExternalHelpers( result.metadata.usedHelpers );
+		result.code = helpers + '\n\n' + result.code;
+	}
+	return result;
 }
 
 babel.defaults = {


### PR DESCRIPTION
Prevent global namespace collision when babel is chained after esperanto-bundle.

``` javascript
gobble( 'src' )
    .transform( 'esperanto-bundle', { 
        entry: 'main', 
        type: 'umd', 
        name: 'Lib', 
        dest: 'lib.js' 
    })
    .transform( 'babel', { 
        blacklist: ['strict'],
        externalHelpers: true 
    })
```
